### PR TITLE
Fix incorrect target length when parsing multibyte UTF-8 characters

### DIFF
--- a/src/main/kotlin/de/skyrising/mc/scanner/io.kt
+++ b/src/main/kotlin/de/skyrising/mc/scanner/io.kt
@@ -58,15 +58,18 @@ class ByteBufferDataInput(private val buf: ByteBuffer) : DataInput {
             skipBytes(count)
             return String(chars, 0, count)
         }
-        return readUTF(chars, count, pos)
+        return readUTF(chars, count, pos, utflen)
     }
 
-    private fun readUTF(chararr: CharArray, start: Int, pos: Int): String {
+    private fun readUTF(chararr: CharArray, start: Int, pos: Int, utflen: Int): String {
         var count = start
         var char2: Int
         var char3: Int
-        var chararrCount = 0
-        while (count < chararr.size) {
+        var chararrCount = count
+	if (utflen > chararr.size) {
+	    throw IllegalArgumentException("utflen $utflen is greater than chararr size $chararr.size")
+	}
+        while (count < utflen) {
             val c = buf[pos + count].toInt() and 0xff
             when (c shr 4) {
                 0, 1, 2, 3, 4, 5, 6, 7 -> { /* 0xxxxxxx*/
@@ -99,7 +102,7 @@ class ByteBufferDataInput(private val buf: ByteBuffer) : DataInput {
                         "malformed input around byte $count")
             }
         }
-        skipBytes(chararr.size)
+        skipBytes(utflen)
         return String(chararr, 0, chararrCount)
     }
 }


### PR DESCRIPTION
**This pull request is based on the 0.5.1 release because I was unable to run the current master version**

The character array buffer used for decoding UTF-8 characters is resized dynamically based on strings that are being parsed. However, the UTF-8 decoding always assumed that the length of the allocated array was equal to the expected length of the string. This means that if a very long string was parsed before a string containing a multi-byte character, the length would be incorrectly interpreted to be that of the previous long string instead of the string being currently parsed, resulting in the code reading past the end of the string and reading garbage.

This bug caused chunks that contained items with lore text using multi-byte characters to be completely ignored in statistics.

The fix is to pass the expected length into the readUTF function, and use it instead of relying on the size of the buffer.